### PR TITLE
add options to supply weights and controls, and to choose the kernel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: This package offers a simultaneous implementation of two major
 License: file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 URL: https://arxiv.org/abs/2205.04345
 BugReports: https://github.com/SMasa11/rdtest/issues
 Suggests: 

--- a/R/compute_test_stat.R
+++ b/R/compute_test_stat.R
@@ -4,6 +4,9 @@
 
 compute_test_stat <- function(df_data,
                             int_dim_Z,
+                            weights = NULL,
+                            covs = NULL,
+                            kernel = "triangular",
                             int_J = 3,
                             bool_max_test = FALSE,
                             bool_L2_std = FALSE,
@@ -95,6 +98,9 @@ compute_test_stat <- function(df_data,
         list_result_rdrobust_Z <- rdrobust::rdrobust(
           y=df_data$vec_Z.1,
           x = df_data$vec_X,
+          covs = covs,
+          kernel = kernel,
+          weights = weights,
           rho=1,
           bwselect='mserd'
         )},
@@ -107,7 +113,7 @@ compute_test_stat <- function(df_data,
       tryCatch({
         eval(parse(text = paste0(paste0(
           "list_result_rdrobust_Z <- rdrobust::rdrobust(y=df_data$vec_Z.",d),
-          ",x = df_data$vec_X,rho=1,bwselect='mserd')"
+          ",x = df_data$vec_X,covs=covs,kernel=kernel,weights = weights,rho=1,bwselect='mserd')"
         )))},
         error = function(e) {
           message(paste0("ERROR at rdrobust for vec_Z.",d))
@@ -128,7 +134,7 @@ compute_test_stat <- function(df_data,
     tryCatch({
       eval(parse(text = paste0(paste0(
         "list_result_rdrobust_Z_bias <- rdrobust::rdrobust(y=df_data$vec_Z.",d),
-        ",x=df_data$vec_X,p=2,rho=1,h=c(vec_h_L[d],vec_h_R[d]))"
+        ",x=df_data$vec_X,covs=covs,kernel=kernel,weights=weights,p=2,rho=1,h=c(vec_h_L[d],vec_h_R[d]))"
         )))},
       error = function(e) {
         message(paste0("ERROR at calculating bias rdrobust for vec_Z.",d))

--- a/R/return_result_joint.R
+++ b/R/return_result_joint.R
@@ -1,6 +1,10 @@
 #' return joint test result
 #'
 #' @param df_data Data.frame, data to evaluate.
+#' @param weights Weights of observations that multiply the kernel function.
+#' @param covs Data.frame or Vector, optional control covariates for rdrobust.
+#' @param kernel is the kernel function used to construct the local-polynomial
+#'   estimator(s). Options are triangular (default option), epanechnikov and uniform.
 #' @param int_dim_Z Integer, dimension of covariates.
 #' @param int_J Integer, nearest neighbor for the variance estimation <= 3
 #'  default is 3.
@@ -11,6 +15,9 @@
 
 return_result_joint <- function(df_data,
                                int_dim_Z,
+                               weights = NULL,
+                               covs = NULL,
+                               kernel = "triangular",
                                int_J = 3,
                                bool_max_test = FALSE,
                                bool_L2_std = TRUE,
@@ -22,6 +29,9 @@ return_result_joint <- function(df_data,
   list_result_covariate <-
     compute_test_stat(df_data = df_data,
                     int_dim_Z = int_dim_Z,
+                    weights = weights,
+                    covs = covs,
+                    kernel = kernel,
                     bool_joint = bool_joint,
                     int_J = int_J,
                     bool_L2_std = bool_L2_std,
@@ -35,7 +45,7 @@ return_result_joint <- function(df_data,
   int_dim_total <- int_dim_Z + bool_joint
   # Xstat
   tryCatch({
-    list_result_X <- rddensity::rddensity(X = df_data$vec_X)},
+    list_result_X <- rddensity::rddensity(X = df_data$vec_X, kernel = kernel)},
     error = function(e) {
       message(paste0("ERROR at rddensity"))
       message(e)

--- a/man/compute_test_stat.Rd
+++ b/man/compute_test_stat.Rd
@@ -7,6 +7,9 @@
 compute_test_stat(
   df_data,
   int_dim_Z,
+  weights = NULL,
+  covs = NULL,
+  kernel = "triangular",
   int_J = 3,
   bool_max_test = FALSE,
   bool_L2_std = FALSE,
@@ -17,6 +20,13 @@ compute_test_stat(
 \item{df_data}{Data.frame, data to evaluate.}
 
 \item{int_dim_Z}{Integer, dimension of covariates.}
+
+\item{weights}{Weights of observations that multiply the kernel function.}
+
+\item{covs}{Data.frame or Vector, optional control covariates for rdrobust.}
+
+\item{kernel}{is the kernel function used to construct the local-polynomial
+estimator(s). Options are triangular (default option), epanechnikov and uniform.}
 
 \item{int_J}{Integer, nearest neighbor for the variance estimation <= 3
 default is 3.}

--- a/man/rdtest.Rd
+++ b/man/rdtest.Rd
@@ -7,6 +7,9 @@
 rdtest(
   Z,
   vec_X,
+  weights = NULL,
+  covs = NULL,
+  kernel = "triangular",
   bool_joint = TRUE,
   int_J = 3,
   real_cutoff = 0,
@@ -18,6 +21,16 @@ rdtest(
 \item{Z}{Data.frame or Vector, pre-determined covariates.}
 
 \item{vec_X}{Vector, running variable X.}
+
+\item{weights}{Vector, variable used for optional weighting of the estimation
+procedure. The unit-specific weights multiply the kernel function. Note that
+weights are not applied to the density test, as rddensity does not allow
+weights.}
+
+\item{covs}{Data.frame or Vector, optional control covariates for rdrobust.}
+
+\item{kernel}{is the kernel function used to construct the local-polynomial
+estimator(s). Options are triangular (default option), epanechnikov and uniform.}
 
 \item{bool_joint}{Boolean, TRUE if joint test instead of balance test only,
 default is TRUE.}

--- a/man/return_result_joint.Rd
+++ b/man/return_result_joint.Rd
@@ -7,6 +7,9 @@
 return_result_joint(
   df_data,
   int_dim_Z,
+  weights = NULL,
+  covs = NULL,
+  kernel = "triangular",
   int_J = 3,
   bool_max_test = FALSE,
   bool_L2_std = TRUE,
@@ -17,6 +20,13 @@ return_result_joint(
 \item{df_data}{Data.frame, data to evaluate.}
 
 \item{int_dim_Z}{Integer, dimension of covariates.}
+
+\item{weights}{Weights of observations that multiply the kernel function.}
+
+\item{covs}{Data.frame or Vector, optional control covariates for rdrobust.}
+
+\item{kernel}{is the kernel function used to construct the local-polynomial
+estimator(s). Options are triangular (default option), epanechnikov and uniform.}
 
 \item{int_J}{Integer, nearest neighbor for the variance estimation <= 3
 default is 3.}


### PR DESCRIPTION
Add options to specify weights and to specify control variables that are passed to the the underlying rdrobust function (not to rddensity, as rddensity does not allow weights).

Also added the option to choose the kernel for rddensity and rdrobust - either triangular, uniform or epanechnikov.